### PR TITLE
API-4005: Removed calls to Service Locator as it is being retired

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/config/microserviceGlobal.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/config/microserviceGlobal.scala
@@ -21,13 +21,11 @@ import com.typesafe.config.Config
 import net.ceedubs.ficus.Ficus._
 import play.api.Mode.Mode
 import play.api.libs.json.Json
-import play.api.mvc.{Handler, RequestHeader, Result}
 import play.api.mvc.Results._
+import play.api.mvc.{Handler, RequestHeader, Result}
 import play.api.{Application, Configuration, Logger, Play}
-import uk.gov.hmrc.api.config.ServiceLocatorConfig
-import uk.gov.hmrc.api.connector.ServiceLocatorConnector
 import uk.gov.hmrc.auth.core.AuthorisationException
-import uk.gov.hmrc.http.{CorePost, HeaderCarrier, TooManyRequestException}
+import uk.gov.hmrc.http.TooManyRequestException
 import uk.gov.hmrc.individualsincomeapi.domain.JsonFormatters.errorInvalidRequestFormat
 import uk.gov.hmrc.individualsincomeapi.domain.{ErrorInternalServer, ErrorInvalidRequest, ErrorUnauthorized}
 import uk.gov.hmrc.individualsincomeapi.play.RequestHeaderUtils._
@@ -54,7 +52,6 @@ object MicroserviceLoggingFilter extends LoggingFilter with MicroserviceFilterSu
 
 object MicroserviceGlobal
   extends DefaultMicroserviceGlobal
-    with ServiceLocatorConfig
     with MicroserviceFilterSupport
     with ConfigSupport {
 
@@ -100,30 +97,6 @@ object MicroserviceGlobal
     maybeInvalidRequest match {
       case Some(errorResponse) => Future.successful(errorResponse.toHttpResponse)
       case _ => Future.successful(ErrorInvalidRequest("Invalid Request").toHttpResponse)
-    }
-  }
-
-  // need to inline most of the old play-hmrc-api code because the old version isn't compatible with the new libraries
-  // and the new version requires the bootstrap-play migration
-  private lazy val slConnector = new ServiceLocatorConnector {
-    override def appName: String = AppName(playConfiguration).appName
-
-    override val appUrl: String = playConfiguration.getString("appUrl").getOrElse(throw new RuntimeException("appUrl is not configured"))
-    override val serviceUrl: String = serviceLocatorUrl
-    override val handlerOK: () => Unit = () => Logger.info("Service is registered on the service locator")
-    override val handlerError: Throwable => Unit = e => Logger.error(s"Service could not register on the service locator", e)
-    override val metadata: Option[Map[String, String]] = Some(Map("third-party-api" -> "true"))
-    override val http: CorePost = WSHttp
-  }
-
-  private lazy val registrationEnabled = playConfiguration.getBoolean("microservice.services.service-locator.enabled").getOrElse(false)
-
-  override def onStart(app: Application): Unit = {
-    super.onStart(app)
-    if (registrationEnabled) {
-      slConnector.register(HeaderCarrier())
-    } else {
-      Logger.warn("Registration in Service Locator is disabled")
     }
   }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -159,11 +159,6 @@ microservice {
       port = 8500
     }
 
-    service-locator {
-      host = localhost
-      port = 9602
-    }
-
     individuals-matching-api {
       host = localhost
       port = 9653


### PR DESCRIPTION
Microservices no longer need to call Service Locator to register their deployments - this is now handled as part of the Deploy to... Jenkins jobs. There is a related PR to cover the update to pipeline at hmrc/build-jobs#4101

Service Locator is in the process of being retired entirely, so any calls to it will fail. This PR removes the redundant call.

Further detail: https://confluence.tools.tax.service.gov.uk/x/bGNjCQ