### PR TITLE
MDS-382 | Changes from latest if schemas

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPaye.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPaye.scala
@@ -24,13 +24,29 @@ object IfPaye {
 
   val minValue = -9999999999.99
   val maxValue = 9999999999.99
+  val payeWholeUnitsPaymentTypeMinValue = -99999
+  val payeWholeUnitsPaymentTypeMaxValue = 99999
+  val payeWholeUnitsPositivePaymentTypeMinValue = 0
+  val payeWholeUnitsPositivePaymentTypeMaxValue = 99999
 
   def isMultipleOfPointZeroOne(value: Double): Boolean = (BigDecimal(value) * 100.0) % 1 == 0
 
-  def isInRange(value: Double): Boolean = value > minValue && value < maxValue
+  def isInRange(value: Double): Boolean = value >= minValue && value <= maxValue
+
+  def isInRangeWholeUnits(value: Double): Boolean =
+    value >= payeWholeUnitsPaymentTypeMinValue && value <= payeWholeUnitsPaymentTypeMaxValue
+
+  def isInRangePositiveWholeUnits(value: Double): Boolean =
+    value >= payeWholeUnitsPositivePaymentTypeMinValue && value <= payeWholeUnitsPositivePaymentTypeMaxValue
 
   def paymentAmountValidator(implicit rds: Reads[Double]): Reads[Double] =
     verifying[Double](value => isInRange(value) && isMultipleOfPointZeroOne(value))
+
+  def payeWholeUnitsPaymentTypeValidator(implicit rds: Reads[Int]): Reads[Int] =
+    verifying[Int](value => isInRangeWholeUnits(value))
+
+  def payeWholeUnitsPositivePaymentTypeValidator(implicit rds: Reads[Int]): Reads[Int] =
+    verifying[Int](value => isInRangePositiveWholeUnits(value))
 
   implicit val incomePayeFormat: Format[IfPaye] = Format(
     (JsPath \ "paye").read[Seq[IfPayeEntry]].map(value => IfPaye(value)),

--- a/app/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPayeEntry.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPayeEntry.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.individualsincomeapi.domain.integrationframework.paye
 import play.api.libs.functional.syntax.{unlift, _}
 import play.api.libs.json.{Format, JsPath, Reads}
 import play.api.libs.json.Reads.{maxLength, minLength, pattern, verifying}
-import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.paye.IfPaye.paymentAmountValidator
+import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.paye.IfPaye._
 
 case class IfGrossEarningsForNics(
                                    inPayPeriod1: Option[Double],
@@ -64,13 +64,13 @@ case class IfBenefits(
 
 case class IfStudentLoan(
                           planType: Option[String],
-                          repaymentsInPayPeriod: Option[Double],
-                          repaymentsYTD: Option[Double]
+                          repaymentsInPayPeriod: Option[Int],
+                          repaymentsYTD: Option[Int]
                         )
 
 case class IfPostGradLoan(
-                           repaymentsInPayPeriod: Option[Double],
-                           repaymentsYtd: Option[Double]
+                           repaymentsInPayPeriod: Option[Int],
+                           repaymentsYtd: Option[Int]
                          )
 
 case class IfPayeEntry(
@@ -208,24 +208,24 @@ object IfPayeEntry {
     (
       (JsPath \ "planType")
         .readNullable[String](pattern(studentLoanPlanTypePattern, "Invalid student loan plan type")) and
-        (JsPath \ "repaymentsInPayPeriod").readNullable[Double](paymentAmountValidator) and
-        (JsPath \ "repaymentsYTD").readNullable[Double](paymentAmountValidator)
+        (JsPath \ "repaymentsInPayPeriod").readNullable[Int](payeWholeUnitsPaymentTypeValidator) and
+        (JsPath \ "repaymentsYTD").readNullable[Int](payeWholeUnitsPositivePaymentTypeValidator)
       )(IfStudentLoan.apply _),
     (
       (JsPath \ "planType").writeNullable[String] and
-        (JsPath \ "repaymentsInPayPeriod").writeNullable[Double] and
-        (JsPath \ "repaymentsYTD").writeNullable[Double]
+        (JsPath \ "repaymentsInPayPeriod").writeNullable[Int] and
+        (JsPath \ "repaymentsYTD").writeNullable[Int]
       )(unlift(IfStudentLoan.unapply))
   )
 
   implicit val postGradLoanFormat: Format[IfPostGradLoan] = Format(
     (
-      (JsPath \ "repaymentsInPayPeriod").readNullable[Double](paymentAmountValidator) and
-        (JsPath \ "repaymentsYTD").readNullable[Double](paymentAmountValidator)
+      (JsPath \ "repaymentsInPayPeriod").readNullable[Int](payeWholeUnitsPaymentTypeValidator) and
+        (JsPath \ "repaymentsYTD").readNullable[Int](payeWholeUnitsPositivePaymentTypeValidator)
       )(IfPostGradLoan.apply _),
     (
-      (JsPath \ "repaymentsInPayPeriod").writeNullable[Double] and
-        (JsPath \ "repaymentsYTD").writeNullable[Double]
+      (JsPath \ "repaymentsInPayPeriod").writeNullable[Int] and
+        (JsPath \ "repaymentsYTD").writeNullable[Int]
       )(unlift(IfPostGradLoan.unapply))
   )
 

--- a/test/unit/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPayeEntrySpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPayeEntrySpec.scala
@@ -52,9 +52,9 @@ class IfPayeEntrySpec extends WordSpec with Matchers {
 
   val validBenefits = IfBenefits(Some(506328.1), Some(246594.83))
 
-  val validStudentLoan = IfStudentLoan(Some("02"), Some(88478.16), Some(545.52))
+  val validStudentLoan = IfStudentLoan(Some("02"), Some(88478), Some(545))
 
-  val validPostGradLoan = IfPostGradLoan(Some(15636.22), Some(46849.26))
+  val validPostGradLoan = IfPostGradLoan(Some(99999), Some(46849))
 
   val validGrossEarningsForNics =
     IfGrossEarningsForNics(Some(169731.51), Some(173987.07), Some(822317.49), Some(818841.65))
@@ -166,12 +166,12 @@ class IfPayeEntrySpec extends WordSpec with Matchers {
           |    },
           |    "studentLoan": {
           |        "planType": "02",
-          |        "repaymentsInPayPeriod": 88478.16,
-          |        "repaymentsYTD": 545.52
+          |        "repaymentsInPayPeriod": 88478,
+          |        "repaymentsYTD": 545
           |    },
           |    "postGradLoan": {
-          |        "repaymentsInPayPeriod": 15636.22,
-          |        "repaymentsYTD": 46849.26
+          |        "repaymentsInPayPeriod": 99999,
+          |        "repaymentsYTD": 46849
           |    }
           |}
           |""".stripMargin

--- a/test/unit/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPostGradLoanSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfPostGradLoanSpec.scala
@@ -23,16 +23,16 @@ import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.paye.IfPayeE
 
 class IfPostGradLoanSpec extends WordSpec with Matchers {
 
-  val validPostGradLoan = IfPostGradLoan(Some(1588498.34), Some(2217757.33))
-  val invalidPostGradLoan = IfPostGradLoan(Some(9999999999.99 + 1), Some(9999999999.99 + 1))
+  val validPostGradLoan = IfPostGradLoan(Some(99999), Some(22177))
+  val invalidPostGradLoan = IfPostGradLoan(Some(99999 + 1), Some(-5))
 
   "IfPostGradLoan" should {
     "Write to json" in {
       val expectedJson = Json.parse(
         """
           |{
-          |  "repaymentsInPayPeriod": 1588498.34,
-          |  "repaymentsYTD": 2217757.33
+          |  "repaymentsInPayPeriod": 99999,
+          |  "repaymentsYTD": 22177
           |}
           |""".stripMargin
       )

--- a/test/unit/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfStudentLoanSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsincomeapi/domain/integrationframework/paye/IfStudentLoanSpec.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.paye.IfStude
 
 class IfStudentLoanSpec extends WordSpec with Matchers {
   val validStudentLoan = IfStudentLoan(Some("01"), Some(100), Some(100))
-  val invalidStudentLoan = IfStudentLoan(Some("NotValid"), Some(9999999999.99 + 1), Some(9999999999.99 + 1))
+  val invalidStudentLoan = IfStudentLoan(Some("NotValid"), Some(99999 + 1), Some(99999 + 1))
 
   "Student Loan" should {
     "WriteToJson" in {

--- a/test/utils/IncomePayeHelpers.scala
+++ b/test/utils/IncomePayeHelpers.scala
@@ -73,9 +73,9 @@ trait IncomePayeHelpers {
 
   private def createValidBenefits() = IfBenefits(Some(506328.1), Some(246594.83))
 
-  private def createValidStudentLoan() = IfStudentLoan(Some("02"), Some(88478.16), Some(545.52))
+  private def createValidStudentLoan() = IfStudentLoan(Some("02"), Some(88478), Some(545))
 
-  private def createValidPostGradLoan() = IfPostGradLoan(Some(15636.22), Some(46849.26))
+  private def createValidPostGradLoan() = IfPostGradLoan(Some(15636), Some(46849))
 
   private def createValodIFGrossEarningsForNics() =
     IfGrossEarningsForNics(Some(169731.51), Some(173987.07), Some(822317.49), Some(818841.65))


### PR DESCRIPTION
The changes since version 1.2.0 are:
 
```
1) Documentation - wording changes to make clear that for Self Assessment a tax year range is used and for PAYE a date range is used
2) Amended the type 'payeWholeUnitsPaymentType' and applied it to the PAYE properties 'repaymentsInPayPeriod' (for Student Loans and Post Grad loans)
3) Added the type 'payeWholeUnitsPositivePaymentType' and applied it to the PAYE properties 'repaymentsYTD' (for Student Loans and Post Grad loans)
4) Removed the "uniqueItems" constraint from the SA "sa" and "returnList" arrays, and from the PAYE "paye" array. This to allow duplicate array entries (anonymous objects) as a result of a consumer's filtering request in the 'fields' query parameter
5) Removed the fractional seconds from the example PAYE properties that use the JSON date-time format
6) Amended the example PAYE response properties 'repaymentsInPayPeriod' and 'repaymentsYTD' to make them valid
7) Amended several example response fractional values (purely to avoid warnings in Stoplight Studio v2.1.0)
```
 
Highlighted changes 2, 3, and 4 are the functional ones related to the mistakes found with the monetary properties within the “studentLoan” and “postGradLoan” objects.