### PR TITLE
MDS-448 | Error handling

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/domain/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/domain/ErrorResponses.scala
@@ -28,8 +28,8 @@ sealed abstract class ErrorResponse(val httpStatusCode: Int, val errorCode: Stri
 
 case class ErrorInvalidRequest(errorMessage: String) extends ErrorResponse(BAD_REQUEST, "INVALID_REQUEST", errorMessage)
 case class ErrorUnauthorized(errorMessage: String) extends ErrorResponse(UNAUTHORIZED, "UNAUTHORIZED", errorMessage)
-case object ErrorInternalServer
-    extends ErrorResponse(INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "Failed to process request")
+case class ErrorInternalServer(errorMessage: String = "Failed to process request")
+    extends ErrorResponse(INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", errorMessage)
 case object ErrorNotFound extends ErrorResponse(NOT_FOUND, "NOT_FOUND", "The resource can not be found")
 case object ErrorTooManyRequests extends ErrorResponse(TOO_MANY_REQUESTS, "TOO_MANY_REQUESTS", "Rate limit exceeded")
 

--- a/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/CommonControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/CommonControllerSpec.scala
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.uk.gov.hmrc.individualsincomeapi.controllers.v2
+
+import java.util.UUID
+
+import component.uk.gov.hmrc.individualsincomeapi.stubs.{AuthStub, BaseSpec}
+import play.api.libs.json.Json
+import scalaj.http.Http
+import play.api.test.Helpers._
+
+trait CommonControllerSpec extends BaseSpec {
+
+  val rootScope: List[String]
+  val endpoint: String
+
+  val matchId: String
+  val fromDate: String
+  val toDate: String
+
+  def invokeEndpoint(endpoint: String) =
+    Http(endpoint)
+      .timeout(10000, 10000)
+      .headers(requestHeaders(acceptHeaderP2))
+      .asString
+
+  feature("Common Controller Methods") {
+
+    scenario("Missing match id") {
+
+      When("the root entry point to the API is invoked with a missing match id")
+      val response = invokeEndpoint(s"$serviceUrl/$endpoint")
+
+      Then("the response status should be 400 (bad request)")
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "INVALID_REQUEST",
+        "message" -> "matchId is required"
+      )
+    }
+
+    scenario("malformed match id") {
+
+      When(
+        "the root entry point to the API is invoked with a malformed match id")
+      val response =
+        invokeEndpoint(
+          s"$serviceUrl/${endpoint}?matchId=malformed-match-id-value")
+
+      Then("the response status should be 400 (bad request)")
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "INVALID_REQUEST",
+        "message" -> "matchId format is invalid"
+      )
+    }
+
+    scenario("invalid match id") {
+
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+      When(
+        "the root entry point to the API is invoked with an invalid match id")
+      val response = invokeEndpoint(
+        s"$serviceUrl/${endpoint}?matchId=0a184ef3-fd75-4d4d-b6a3-f886cc39a366&fromDate=$fromDate")
+
+      Then("the response status should be 404 (not found)")
+      response.code shouldBe NOT_FOUND
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "NOT_FOUND",
+        "message" -> "The resource can not be found"
+      )
+    }
+
+    scenario("missing from date") {
+
+      Given("A valid auth token ")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+      When(s"I make a call to ${endpoint} endpoint")
+      val response =
+        Http(s"$serviceUrl/${endpoint}?matchId=$matchId&toDate=$toDate")
+          .headers(requestHeaders(acceptHeaderP2))
+          .asString
+
+      Then("The response status should be 400")
+
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "INVALID_REQUEST",
+        "message" -> "fromDate is required"
+      )
+    }
+
+    scenario("toDate earlier than fromDate") {
+
+      Given("a valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+      When(
+        s"the ${endpoint} endpoint is invoked with an toDate earlier than fromDate")
+      val response =
+        Http(
+          s"$serviceUrl/${endpoint}?matchId=$matchId&fromDate=$toDate&toDate=$fromDate")
+          .headers(requestHeaders(acceptHeaderP2))
+          .asString
+
+      Then("the response status should be 400 (invalid request)")
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "INVALID_REQUEST",
+        "message" -> "Invalid time period requested"
+      )
+    }
+
+    scenario("From date requested is earlier than 31st March 2013") {
+
+      Given("a valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+      When(
+        s"the ${endpoint} endpoint is invoked with toDate before 31st March 2013")
+      val response = Http(
+        s"$serviceUrl/${endpoint}?matchId=$matchId&fromDate=2012-01-01&toDate=$toDate")
+        .headers(requestHeaders(acceptHeaderP2))
+        .asString
+
+      Then("the response status should be 400 (invalid request)")
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "INVALID_REQUEST",
+        "message" -> "fromDate earlier than 31st March 2013"
+      )
+    }
+
+    scenario("Invalid fromDate") {
+
+      Given("a valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+      When("the paye endpoint is invoked with an invalid match id")
+      val response = Http(s"$serviceUrl/paye?matchId=$matchId&fromDate=20xx-01-01&toDate=$toDate")
+        .headers(requestHeaders(acceptHeaderP2))
+        .asString
+
+      Then("the response status should be 400 (invalid request)")
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code"    -> "INVALID_REQUEST",
+        "message" -> "fromDate: invalid date format"
+      )
+
+    }
+
+    scenario("Invalid toDate") {
+
+      Given("a valid privileged Auth bearer token")
+      AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+      When("the paye endpoint is invoked with an invalid match id")
+      val response = Http(s"$serviceUrl/paye?matchId=$matchId&fromDate=$toDate&toDate=20xx-01-01")
+        .headers(requestHeaders(acceptHeaderP2))
+        .asString
+
+      Then("the response status should be 400 (invalid request)")
+      response.code shouldBe BAD_REQUEST
+      Json.parse(response.body) shouldBe Json.obj(
+        "code"    -> "INVALID_REQUEST",
+        "message" -> "toDate: invalid date format"
+      )
+
+    }
+  }
+}

--- a/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/LiveRootControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/LiveRootControllerSpec.scala
@@ -74,6 +74,23 @@ class LiveRootControllerSpec extends BaseSpec {
       )
     }
 
+    scenario(s"user does not have valid scopes") {
+      Given("A valid auth token but invalid scopes")
+      AuthStub.willNotAuthorizePrivilegedAuthTokenNoScopes(authToken)
+
+      When("the API is invoked")
+      val response = Http(s"$serviceUrl/?matchId=$matchId")
+        .headers(requestHeaders(acceptHeaderP2))
+        .asString
+
+      Then("The response status should be 401")
+      response.code shouldBe UNAUTHORIZED
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "UNAUTHORIZED",
+        "message" ->"Insufficient Enrolments"
+      )
+    }
+
     scenario("missing match id") {
       Given("a valid privileged Auth bearer token")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, allIncomeScopes)
@@ -167,5 +184,7 @@ class LiveRootControllerSpec extends BaseSpec {
     }
 
   }
+
+
 
 }

--- a/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/LiveSaIncomeControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/LiveSaIncomeControllerSpec.scala
@@ -173,7 +173,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       And("a valid record in the matching API")
@@ -264,7 +264,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("I request the self assessments")
@@ -282,7 +282,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       And("a valid record in the matching API")
@@ -381,7 +381,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment employments returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, employmentScopes)
 
       And("a valid record in the matching API")
@@ -421,7 +421,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, employmentScopes)
 
       When("I request the self assessments")
@@ -439,7 +439,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, employmentScopes)
 
       And("a valid record in the matching API")
@@ -544,7 +544,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment self employments returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, selfAssessmentScopes)
 
       And("a valid record in the matching API")
@@ -584,7 +584,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, selfAssessmentScopes)
 
       When("I request the self assessments")
@@ -602,7 +602,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, selfAssessmentScopes)
 
       And("a valid record in the matching API")
@@ -703,7 +703,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment summary returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, summaryScopes)
 
       And("a valid record in the matching API")
@@ -743,7 +743,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, summaryScopes)
 
       When("I request the self assessments")
@@ -761,7 +761,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, summaryScopes)
 
       And("a valid record in the matching API")
@@ -860,7 +860,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment trusts returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, trustsScopes)
 
       And("a valid record in the matching API")
@@ -900,7 +900,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, trustsScopes)
 
       When("I request the self assessments")
@@ -918,7 +918,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, trustsScopes)
 
       And("a valid record in the matching API")
@@ -1025,7 +1025,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment foreign returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, foreignScopes)
 
       And("a valid record in the matching API")
@@ -1065,7 +1065,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, foreignScopes)
 
       When("I request the self assessments")
@@ -1083,7 +1083,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, foreignScopes)
 
       And("a valid record in the matching API")
@@ -1183,7 +1183,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment partnerships returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, partnershipsScopes)
 
       And("a valid record in the matching API")
@@ -1223,7 +1223,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, partnershipsScopes)
 
       When("I request the self assessments")
@@ -1241,7 +1241,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, partnershipsScopes)
 
       And("a valid record in the matching API")
@@ -1352,7 +1352,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment interests and dividends returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, interestsAndDividendsScopes)
 
       And("a valid record in the matching API")
@@ -1393,7 +1393,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, interestsAndDividendsScopes)
 
       When("I request the self assessments")
@@ -1412,7 +1412,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, interestsAndDividendsScopes)
 
       And("a valid record in the matching API")
@@ -1513,7 +1513,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment pensions and benefits returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, pensionsAndStateBenefitsScopes)
 
       And("a valid record in the matching API")
@@ -1554,7 +1554,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("An invalid token")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, pensionsAndStateBenefitsScopes)
 
       When("I request the self assessments")
@@ -1573,7 +1573,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with valid scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, pensionsAndStateBenefitsScopes)
 
       And("a valid record in the matching API")
@@ -1676,7 +1676,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment uk properties returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, ukPropertiesScopes)
 
       And("a valid record in the matching API")
@@ -1717,7 +1717,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, ukPropertiesScopes)
 
       When("I request the self assessments")
@@ -1736,7 +1736,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, ukPropertiesScopes)
 
       And("a valid record in the matching API")
@@ -1838,7 +1838,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment additional information returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, additionalInformationScopes)
 
       And("a valid record in the matching API")
@@ -1879,7 +1879,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, additionalInformationScopes)
 
       When("I request the self assessments")
@@ -1898,7 +1898,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, additionalInformationScopes)
 
       And("a valid record in the matching API")
@@ -1999,7 +1999,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment other income returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, otherIncomeScopes)
 
       And("a valid record in the matching API")
@@ -2040,7 +2040,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, otherIncomeScopes)
 
       When("I request the self assessments")
@@ -2059,7 +2059,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, otherIncomeScopes)
 
       And("a valid record in the matching API")
@@ -2175,7 +2175,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("Fetch Self Assessment further details income returns no root data") {
 
       val toTaxYear = "2021"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, furtherDetailsScopes)
 
       And("a valid record in the matching API")
@@ -2216,7 +2216,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     scenario("Invalid token") {
 
-      Given("A token WITHOUT the scope read:individuals-income-sa")
+      Given("A token WITHOUT the required scopes")
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, furtherDetailsScopes)
 
       When("I request the self assessments")
@@ -2235,7 +2235,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
     scenario("The self assessment data source is rate limited") {
 
       val toTaxYear = "2020"
-      Given("A privileged Auth bearer token with scope read:individuals-income-sa")
+      Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, furtherDetailsScopes)
 
       And("a valid record in the matching API")

--- a/test/component/uk/gov/hmrc/individualsincomeapi/stubs/AuthStub.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/stubs/AuthStub.scala
@@ -77,6 +77,17 @@ object AuthStub extends MockHost(22000) {
           .withStatus(Status.UNAUTHORIZED)
           .withHeader(HeaderNames.WWW_AUTHENTICATE, """MDTP detail="Bearer token is missing or not authorized"""")))
 
+  def willNotAuthorizePrivilegedAuthTokenNoScopes(authBearerToken: String): StubMapping =
+    mock.register(
+      post(urlEqualTo("/auth/authorise"))
+        .withHeader(AUTHORIZATION, equalTo(authBearerToken))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.UNAUTHORIZED)
+            .withHeader(
+              HeaderNames.WWW_AUTHENTICATE,
+              """MDTP detail="InsufficientEnrolments"""")))
+
   def willNotAuthorizePrivilegedAuthToken(authBearerToken: String, scope: String): StubMapping =
     mock.register(
       post(urlEqualTo("/auth/authorise"))

--- a/test/component/uk/gov/hmrc/individualsincomeapi/stubs/BaseSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/stubs/BaseSpec.scala
@@ -37,6 +37,7 @@ trait BaseSpec
   override lazy val port = 9000
   implicit override lazy val app: Application = GuiceApplicationBuilder()
     .configure(
+      "cacheV2.enabled"                                          -> false,
       "auditing.enabled"                                       -> false,
       "auditing.traceRequests"                                 -> false,
       "microservice.services.auth.port"                        -> AuthStub.port,

--- a/test/component/uk/gov/hmrc/individualsincomeapi/stubs/IfStub.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/stubs/IfStub.scala
@@ -18,10 +18,11 @@ package component.uk.gov.hmrc.individualsincomeapi.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
 import play.api.http.Status
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.{IfPaye, IfSa}
 
 object IfStub extends MockHost(24000) {
+
 
   def searchPayeIncomeForPeriodReturns(nino: String, fromDate: String, toDate: String, fields: String, ifPaye: IfPaye) =
     mock.register(
@@ -62,6 +63,15 @@ object IfStub extends MockHost(24000) {
         .withQueryParam("endDate", equalTo(toDate))
         .withQueryParam("fields", equalTo(fields))
         .willReturn(aResponse().withStatus(Status.TOO_MANY_REQUESTS)))
+
+  def saCustomResponse(nino: String, status: Int, fromTaxYear: String, toTaxYear: String, fields: String, response: JsValue) =
+    mock.register(
+      get(urlPathEqualTo(s"/individuals/income/sa/nino/$nino"))
+        .withQueryParam("startYear", equalTo(fromTaxYear))
+        .withQueryParam("endYear", equalTo(toTaxYear))
+        .withQueryParam("fields", equalTo(fields))
+        .willReturn(aResponse().withStatus(status).withBody(Json.toJson(response.toString()).toString())))
+
 
   def searchSaIncomeReturnsRateLimitErrorFor(
     nino: String,

--- a/test/it/uk/gov/hmrc/individualsincomeapi/connectors/IfConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsincomeapi/connectors/IfConnectorSpec.scala
@@ -26,7 +26,7 @@ import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, Upstream5xxResponse}
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, InternalServerException, Upstream5xxResponse}
 import uk.gov.hmrc.individualsincomeapi.connector.IfConnector
 import uk.gov.hmrc.integration.ServiceSpec
 import unit.uk.gov.hmrc.individualsincomeapi.util._
@@ -211,7 +211,7 @@ class IfConnectorSpec
         get(urlPathMatching(s"/individuals/income/paye/nino/$nino"))
           .willReturn(aResponse().withStatus(500)))
 
-      intercept[Upstream5xxResponse] {
+      intercept[InternalServerException] {
         await(underTest
           .fetchPayeIncome(nino, interval, None, matchId)(hc, FakeRequest().withHeaders(sampleCorrelationIdHeader), ec))
       }
@@ -229,7 +229,7 @@ class IfConnectorSpec
         get(urlPathMatching(s"/individuals/income/paye/nino/$nino"))
           .willReturn(aResponse().withStatus(400)))
 
-      intercept[BadRequestException] {
+      intercept[InternalServerException] {
         await(underTest
           .fetchPayeIncome(nino, interval, None, matchId)(hc, FakeRequest().withHeaders(sampleCorrelationIdHeader), ec))
       }
@@ -357,7 +357,7 @@ class IfConnectorSpec
         get(urlPathMatching(s"/individuals/income/sa/nino/$nino"))
           .willReturn(aResponse().withStatus(500)))
 
-      intercept[Upstream5xxResponse] {
+      intercept[InternalServerException] {
         await {
           underTest.fetchSelfAssessmentIncome(nino, interval, None, matchId)(
             hc,
@@ -380,7 +380,7 @@ class IfConnectorSpec
         get(urlPathMatching(s"/individuals/income/sa/nino/$nino"))
           .willReturn(aResponse().withStatus(400)))
 
-      intercept[BadRequestException] {
+      intercept[InternalServerException] {
         await {
           underTest.fetchSelfAssessmentIncome(nino, interval, None, matchId)(
             hc,


### PR DESCRIPTION
Updated the error handling so errors are not passed from IF to the user... any 4xxs or 5xxs will get logged and audited, but the user receive an Internal Server Error - "Something went wrong."

Error handling added to cover a lack of valid scopes, instead of returning one of the invalid scopes.

Added a generic, catch-all error ("Something went wrong.")