### PR TITLE
HODS-242

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/domain/v2/SaFootprint.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/domain/v2/SaFootprint.scala
@@ -16,7 +16,11 @@
 
 package uk.gov.hmrc.individualsincomeapi.domain.v2
 
-import play.api.libs.json.Json
+import play.api.libs.functional.syntax.unlift
+import play.api.libs.functional.syntax._
+import play.api.libs.json.Reads.pattern
+import play.api.libs.json.Writes.map
+import play.api.libs.json.{Format, JsPath, Json, Reads, Writes}
 import uk.gov.hmrc.individualsincomeapi.domain.TaxYear
 import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.IfSaEntry
 
@@ -26,7 +30,22 @@ case class SaFootprint(
 )
 
 object SaFootprint {
-  implicit val saFootprintJsonFormat = Json.format[SaFootprint]
+
+  implicit val saFootprintJsonFormat: Format[SaFootprint] = Format(
+    (
+      (JsPath \ "registrations").read[Seq[SaFootprintRegistration]] and
+      (JsPath \ "taxReturns") .read[Seq[SaFootprintTaxReturn]]
+      )(SaFootprint.apply _),
+    (
+      (JsPath \ "registrations").write[Seq[SaFootprintRegistration]] and
+      (JsPath \ "taxReturns").write[Seq[SaFootprintTaxReturn]]
+    )(unlift(SaFootprint.unapply)).contramap(footprint => {
+      val registrations = footprint.registrations
+        .filter(registration => registration.registrationDate.isDefined)
+      val taxReturns = footprint.taxReturns.map(tr => tr.copy(submissions = tr.submissions
+        .filter(submission => submission.receivedDate.isDefined)))
+      footprint.copy(registrations = registrations, taxReturns = taxReturns)})
+  )
 
   def transform(ifSaEntry: Seq[IfSaEntry]): SaFootprint =
     SaFootprint(
@@ -40,7 +59,7 @@ object SaFootprint {
         entryList.returnList.map { returns =>
           returns.map { entry =>
             SaFootprintRegistration(entry.caseStartDate, entry.utr)
-          }
+          }.filter( entry => entry.registrationDate.isDefined)
         }
       }
       .flatten
@@ -53,7 +72,7 @@ object SaFootprint {
       case Some(list) => {
         list.map { entry =>
           SaFootprintSubmission(entry.receivedDate, entry.utr)
-        }
+        }.filter( entry => entry.receivedDate.isDefined)
       }
       case _ => Seq(default)
     }

--- a/test/unit/uk/gov/hmrc/individualsincomeapi/domain/v2/SaFootprintSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsincomeapi/domain/v2/SaFootprintSpec.scala
@@ -18,7 +18,8 @@ package unit.uk.gov.hmrc.individualsincomeapi.domain.v2
 
 import org.scalatest.{Matchers, WordSpec}
 import play.api.libs.json.Json
-import uk.gov.hmrc.individualsincomeapi.domain.v2.SaFootprint
+import uk.gov.hmrc.individualsincomeapi.domain.integrationframework.IfSaEntry
+import uk.gov.hmrc.individualsincomeapi.domain.v2.{SaFootprint, SaFootprintSubmission, SaFootprintTaxReturn}
 import utils.IncomeSaHelpers
 
 class SaFootprintSpec extends WordSpec with Matchers with IncomeSaHelpers {
@@ -61,6 +62,48 @@ class SaFootprintSpec extends WordSpec with Matchers with IncomeSaHelpers {
       val result = Json.toJson(SaFootprint.transform(Seq()))
 
       result shouldBe expectedJson
+    }
+
+    "Write empty array when submissions are without receivedDate" in {
+      val saFootPrint = SaFootprint.transform(ifSa)
+      val submissionsWithoutReceivedDate = saFootPrint.copy( taxReturns =
+          Seq(SaFootprintTaxReturn(
+            "2019-20",
+            Seq( SaFootprintSubmission(
+              receivedDate = None,
+              utr = Some("1234567890"))))))
+
+      val expected = """{
+                       |  "registrations" : [ {
+                       |    "registrationDate" : "2020-01-01",
+                       |    "utr" : "1234567890"
+                       |  } ],
+                       |  "taxReturns" : [ {
+                       |    "taxYear" : "2019-20",
+                       |    "submissions" : [ ]
+                       |  }]
+                       |}""".stripMargin
+
+      Json.toJson(submissionsWithoutReceivedDate) shouldBe Json.parse(expected)
+    }
+
+    "Write empty array when registrations are without registrationDate" in {
+      val saFootPrint = SaFootprint.transform(ifSa)
+      val withoutRegistrations = saFootPrint.copy(registrations = saFootPrint.registrations.map(r => r.copy(registrationDate = None)))
+      val expected = """{
+                       |  "registrations" : [ ],
+                       |  "taxReturns" : [ {
+                       |    "taxYear" : "2019-20",
+                       |    "submissions": [
+                       |        {
+                       |          "receivedDate": "2020-01-01",
+                       |          "utr": "1234567890"
+                       |        }
+                       |      ]
+                       |  } ]
+                       |}""".stripMargin
+
+      Json.toJson(withoutRegistrations) shouldBe Json.parse(expected)
     }
 
   }

--- a/test/unit/uk/gov/hmrc/individualsincomeapi/domain/v2/SaFootprintSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsincomeapi/domain/v2/SaFootprintSpec.scala
@@ -66,7 +66,7 @@ class SaFootprintSpec extends WordSpec with Matchers with IncomeSaHelpers {
 
     "Write empty array when submissions are without receivedDate" in {
       val saFootPrint = SaFootprint.transform(ifSa)
-      val submissionsWithoutReceivedDate = saFootPrint.copy( taxReturns =
+      val withoutReceivedDate = saFootPrint.copy( taxReturns =
           Seq(SaFootprintTaxReturn(
             "2019-20",
             Seq( SaFootprintSubmission(
@@ -84,12 +84,14 @@ class SaFootprintSpec extends WordSpec with Matchers with IncomeSaHelpers {
                        |  }]
                        |}""".stripMargin
 
-      Json.toJson(submissionsWithoutReceivedDate) shouldBe Json.parse(expected)
+      Json.toJson(withoutReceivedDate) shouldBe Json.parse(expected)
     }
 
     "Write empty array when registrations are without registrationDate" in {
       val saFootPrint = SaFootprint.transform(ifSa)
-      val withoutRegistrations = saFootPrint.copy(registrations = saFootPrint.registrations.map(r => r.copy(registrationDate = None)))
+      val withoutRegistrationDate = saFootPrint.copy(registrations =
+        saFootPrint.registrations.map(r => r.copy(registrationDate = None)))
+
       val expected = """{
                        |  "registrations" : [ ],
                        |  "taxReturns" : [ {
@@ -103,8 +105,7 @@ class SaFootprintSpec extends WordSpec with Matchers with IncomeSaHelpers {
                        |  } ]
                        |}""".stripMargin
 
-      Json.toJson(withoutRegistrations) shouldBe Json.parse(expected)
+      Json.toJson(withoutRegistrationDate) shouldBe Json.parse(expected)
     }
-
   }
 }


### PR DESCRIPTION
In income/sa/, If registrationDate is requested and receivedDate isn't (e.g. LAA-C1) then registrations array should have an entry and submissions array should be present but empty. For example:
`{
  "registrations" : [ {
    "registrationDate" : "2020-01-01",
    "utr" : "1234567890"
  } ],
  "taxReturns" : [ {
    "taxYear" : "2019-20",
    "submissions" : [ ]
  }]
}`

If registrationDate is not requested and receivedDate is (e.g. LSANI-C1) then registrations array should be present but empty and submissions should have a single entry. For example:
`{
  "registrations" : [ ],
  "taxReturns" : [ {
    "taxYear" : "2019-20",
    "submissions": [
        {
          "receivedDate": "2020-01-01",
          "utr": "1234567890"
        }
      ]
  } ]
}`

For above examples, see also unit testing in SaFootprintSpec.

If no IF data is returned for the request in either case, then the arrays should be present but empty.