### PR TITLE
DLS-6071 Revert the temporary workaround

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/domain/v1/Individual.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/domain/v1/Individual.scala
@@ -50,7 +50,7 @@ object Payment {
 
 object SandboxIncomeData {
 
-  def findByMatchId(matchId: UUID) = individuals.find(_.matchId == matchId)
+  def findByMatchId(matchId: UUID): Option[Individual] = individuals.find(_.matchId == matchId)
 
   def matchedCitizen(matchId: UUID) = matchId match {
     case `sandboxMatchId` => Some(MatchedCitizen(sandboxMatchId, sandboxNino))
@@ -86,7 +86,7 @@ object SandboxIncomeData {
     ),
     Seq(
       DesSAIncome(
-        "2017",
+        "2018",
         Seq(
           DesSAReturn(
             caseStartDate = Some(parse("2015-01-06")),
@@ -116,7 +116,7 @@ object SandboxIncomeData {
             postalCode = None
           ))
       ),
-      DesSAIncome("2018", Seq(DesSAReturn(Some(parse("2015-01-06")), Some(parse("2018-10-06")), sandboxUtr)))
+      DesSAIncome("2019", Seq(DesSAReturn(Some(parse("2015-01-06")), Some(parse("2018-10-06")), sandboxUtr)))
     )
   )
 }

--- a/test/component/uk/gov/hmrc/individualsincomeapi/TaxYearIntervalValidationSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/TaxYearIntervalValidationSpec.scala
@@ -125,7 +125,7 @@ class TaxYearIntervalValidationSpec extends BaseSpec {
     Scenario("toTaxYear defaults to the current tax year when it is not provided") {
 
       When("I request individual income for the existing matchId without a toTaxYear")
-      val response = Http(s"$serviceUrl/sandbox/sa?matchId=$sandboxMatchId&fromTaxYear=2016-17")
+      val response = Http(s"$serviceUrl/sandbox/sa?matchId=$sandboxMatchId&fromTaxYear=2017-18")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -134,7 +134,7 @@ class TaxYearIntervalValidationSpec extends BaseSpec {
 
       And("The response contains the self-assessment for the period")
       (Json.parse(response.body) \ "selfAssessment" \ "taxReturns" \\ "taxYear")
-        .map(_.as[String]) shouldBe Seq("2017-18", "2016-17")
+        .map(_.as[String]) shouldBe Seq("2018-19", "2017-18")
     }
   }
 }

--- a/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v1/LiveSaIncomeControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v1/LiveSaIncomeControllerSpec.scala
@@ -31,15 +31,15 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
   val matchId = UUID.randomUUID().toString
   val nino = Nino("AA100009B")
-  val fromTaxYear = TaxYear("2016-17")
-  val toTaxYear = TaxYear("2018-19")
+  val fromTaxYear = TaxYear("2017-18")
+  val toTaxYear = TaxYear("2019-20")
   val desIncomes = Seq(
     DesSAIncome(
-      taxYear = "2017",
+      taxYear = "2018",
       returnList = Seq(
         DesSAReturn(
-          caseStartDate = Some(LocalDate.parse("2014-01-15")),
-          receivedDate = Some(LocalDate.parse("2017-11-05")),
+          caseStartDate = Some(LocalDate.parse("2015-01-15")),
+          receivedDate = Some(LocalDate.parse("2018-11-05")),
           utr = SaUtr("2432552644"),
           addressLine1 = Some("address line 1"),
           addressLine2 = Some("address line 2"),
@@ -79,12 +79,12 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa root resources")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
       Then("The response status should be 200 (OK) with the self-assessments")
-      val requestParameters = s"matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+      val requestParameters = s"matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
 
       response.code shouldBe OK
       Json.parse(response.body) shouldBe
@@ -109,16 +109,16 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
                  "registrations": [
                    {
                      "utr": "2432552644",
-                     "registrationDate": "2014-01-15"
+                     "registrationDate": "2015-01-15"
                    }
                  ],
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "submissions": [
                        {
                          "utr": "2432552644",
-                         "receivedDate": "2017-11-05"
+                         "receivedDate": "2018-11-05"
                        }
                      ]
                    }
@@ -133,7 +133,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa")
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -145,7 +145,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
     }
 
     Scenario("The self assessment data source is rate limited") {
-      val toTaxYear = TaxYear("2017-18")
+      val toTaxYear = TaxYear("2018-19")
 
       Given("A privileged Auth bearer token with scope read:individuals-income-sa")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa")
@@ -158,7 +158,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
         .searchSelfAssessmentIncomeForPeriodReturnsRateLimitErrorFor(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa root resources")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2017-18")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2018-19")
         .headers(headers)
         .asString
 
@@ -183,7 +183,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the employments")
-      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -194,12 +194,12 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
           s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "employments": [
                        {
                          "utr":"2432552644",
@@ -218,7 +218,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-employments")
 
       When("I request the employments")
-      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -241,7 +241,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the self employments")
-      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -252,12 +252,12 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
           s"""
            {
              "_links": {
-               "self": {"href": "/individuals/income/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+               "self": {"href": "/individuals/income/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
              },
              "selfAssessment": {
                "taxReturns": [
                  {
-                   "taxYear": "2016-17",
+                   "taxYear": "2017-18",
                    "selfEmployments": [
                      {
                        "utr":"2432552644",
@@ -276,7 +276,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-self-employments")
 
       When("I request the self employments")
-      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -299,7 +299,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa summary")
-      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -310,12 +310,12 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
           s"""
            {
              "_links": {
-               "self": {"href": "/individuals/income/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+               "self": {"href": "/individuals/income/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
              },
              "selfAssessment": {
                "taxReturns": [
                  {
-                   "taxYear": "2016-17",
+                   "taxYear": "2017-18",
                    "summary": [
                      {
                        "utr":"2432552644",
@@ -334,7 +334,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-summary")
 
       When("I request the sa summary")
-      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -357,7 +357,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa trusts income")
-      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -368,12 +368,12 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
           s"""
            {
              "_links": {
-               "self": {"href": "/individuals/income/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+               "self": {"href": "/individuals/income/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
              },
              "selfAssessment": {
                "taxReturns": [
                  {
-                   "taxYear": "2016-17",
+                   "taxYear": "2017-18",
                    "trusts": [
                      {
                        "utr":"2432552644",
@@ -392,7 +392,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-trusts")
 
       When("I request the sa trusts income")
-      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -415,7 +415,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa foreign income")
-      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -427,13 +427,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "foreign": [
                        {
                          "utr": "2432552644",
@@ -452,7 +452,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-foreign")
 
       When("I request the sa foreign income")
-      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -475,7 +475,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa partnerships income")
-      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -487,13 +487,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "partnerships": [
                        {
                          "utr": "2432552644",
@@ -512,7 +512,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-partnerships")
 
       When("I request the sa partnerships income")
-      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -536,7 +536,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the sa interests and dividends income")
       val response =
-        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -548,13 +548,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "interestsAndDividends": [
                        {
                          "utr": "2432552644",
@@ -576,7 +576,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the sa interests and dividends income")
       val response =
-        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -600,7 +600,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the sa pensions and state benefits income")
       val response =
-        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -612,13 +612,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "pensionsAndStateBenefits": [
                        {
                          "utr": "2432552644",
@@ -638,7 +638,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the sa pensions and state benefits income")
       val response =
-        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -661,7 +661,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa UK properties income income")
-      val response = Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -673,13 +673,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "ukProperties": [
                        {
                          "utr": "2432552644",
@@ -698,7 +698,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-uk-properties")
 
       When("I request the sa UK properties income")
-      val response = Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -722,7 +722,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the sa additional information")
       val response =
-        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -734,13 +734,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "additionalInformation": [
                        {
                          "utr": "2432552644",
@@ -761,7 +761,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the sa additional information")
       val response =
-        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -784,7 +784,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa other income")
-      val response = Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -796,13 +796,13 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
             {
               "_links": {
                  "self": {
-                   "href": "/individuals/income/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+                   "href": "/individuals/income/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                  }
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "other": [
                        {
                          "utr": "2432552644",
@@ -821,7 +821,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-other")
 
       When("I request the sa other income")
-      val response = Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -844,7 +844,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       DesStub.searchSelfAssessmentIncomeForPeriodReturns(nino, fromTaxYear, toTaxYear, clientId, desIncomes)
 
       When("I request the sa source")
-      val response = Http(s"$serviceUrl/sa/source?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/source?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -856,12 +856,12 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
           s"""
            {
              "_links": {
-               "self": {"href": "/individuals/income/sa/sources?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+               "self": {"href": "/individuals/income/sa/sources?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
              },
              "selfAssessment": {
                "taxReturns": [
                  {
-                   "taxYear": "2016-17",
+                   "taxYear": "2017-18",
                    "sources" : [ {
                       "utr" : "2432552644",
                       "businessAddress" : {
@@ -884,7 +884,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, "read:individuals-income-sa-source")
 
       When("I request the sa trusts income")
-      val response = Http(s"$serviceUrl/sa/source?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/source?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 

--- a/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v1/SandboxSaIncomeControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v1/SandboxSaIncomeControllerSpec.scala
@@ -20,28 +20,21 @@ import component.uk.gov.hmrc.individualsincomeapi.stubs.BaseSpec
 import play.api.libs.json.Json
 import play.api.test.Helpers.OK
 import scalaj.http.Http
-import uk.gov.hmrc.individualsincomeapi.domain.TaxYear
 import uk.gov.hmrc.individualsincomeapi.domain.v1.SandboxIncomeData.{sandboxMatchId, sandboxUtr}
 
-import java.util.UUID
-
 class SandboxSaIncomeControllerSpec extends BaseSpec {
-
-  val matchId = UUID.randomUUID().toString
-  val fromTaxYear = TaxYear("2013-14")
-  val toTaxYear = TaxYear("2015-16")
 
   Feature("Sandbox individual income") {
 
     Scenario("SA root endpoint for the sandbox implementation") {
 
       When("I request the self-assessments for Sandbox")
-      val response = Http(s"$serviceUrl/sandbox/sa?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sandbox/sa?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
       Then("The response status should be 200 (OK) with a valid payload")
-      val requestParameters = s"matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+      val requestParameters = s"matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"
 
       response.code shouldBe OK
       Json.parse(response.body) shouldBe
@@ -71,7 +64,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                  ],
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "submissions": [
                        {
                          "utr": "$sandboxUtr",
@@ -80,7 +73,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "submissions": [
                        {
                          "utr": "$sandboxUtr",
@@ -98,7 +91,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the SA employments for Sandbox")
       val response =
-        Http(s"$serviceUrl/sandbox/sa/employments?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sandbox/sa/employments?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -109,12 +102,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
           s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/employments?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/employments?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "employments": [
                        {
                          "utr": "$sandboxUtr",
@@ -123,7 +116,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "employments": [
                        {
                          "utr": "$sandboxUtr",
@@ -141,7 +134,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the SA self employments for Sandbox")
       val response =
-        Http(s"$serviceUrl/sandbox/sa/self-employments?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sandbox/sa/self-employments?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -152,12 +145,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
           s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/self-employments?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/self-employments?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "selfEmployments": [
                        {
                          "utr": "$sandboxUtr",
@@ -166,7 +159,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "selfEmployments": [
                        {
                           "utr": "$sandboxUtr",
@@ -184,7 +177,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
 
       When("I request the SA returns summary for Sandbox")
       val response =
-        Http(s"$serviceUrl/sandbox/sa/summary?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sandbox/sa/summary?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -195,12 +188,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
           s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/summary?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/summary?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "summary": [
                        {
                          "utr": "$sandboxUtr",
@@ -209,7 +202,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "summary": [
                        {
                           "utr": "$sandboxUtr",
@@ -226,7 +219,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
     Scenario("SA trusts endpoint for the sandbox implementation") {
       When("I request the SA trusts income for Sandbox")
       val response =
-        Http(s"$serviceUrl/sandbox/sa/trusts?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sandbox/sa/trusts?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -237,12 +230,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
           s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/trusts?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/trusts?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "trusts": [
                        {
                          "utr": "$sandboxUtr",
@@ -251,7 +244,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "trusts": [
                        {
                           "utr": "$sandboxUtr",
@@ -268,7 +261,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
     Scenario("SA foreign endpoint for the sandbox implementation") {
       When("I request the SA foreign income for Sandbox")
       val response =
-        Http(s"$serviceUrl/sandbox/sa/foreign?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sandbox/sa/foreign?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP1))
           .asString
 
@@ -279,12 +272,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
           s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/foreign?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/foreign?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "foreign": [
                        {
                          "utr": "$sandboxUtr",
@@ -293,7 +286,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "foreign": [
                        {
                           "utr": "$sandboxUtr",
@@ -311,7 +304,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
   Scenario("SA partnerships endpoint for the sandbox implementation") {
     When("I request the SA partnerships income for Sandbox")
     val response =
-      Http(s"$serviceUrl/sandbox/sa/partnerships?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      Http(s"$serviceUrl/sandbox/sa/partnerships?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -322,12 +315,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
         s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/partnerships?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/partnerships?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "partnerships": [
                        {
                          "utr": "$sandboxUtr",
@@ -336,7 +329,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "partnerships": [
                        {
                           "utr": "$sandboxUtr",
@@ -353,7 +346,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
   Scenario("SA pensions and state benefits endpoint for the sandbox implementation") {
     When("I request the SA pensions and state benefits income for Sandbox")
     val response = Http(
-      s"$serviceUrl/sandbox/sa/pensions-and-state-benefits?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      s"$serviceUrl/sandbox/sa/pensions-and-state-benefits?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
       .headers(requestHeaders(acceptHeaderP1))
       .asString
 
@@ -364,12 +357,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
         s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "pensionsAndStateBenefits": [
                        {
                          "utr": "$sandboxUtr",
@@ -378,7 +371,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "pensionsAndStateBenefits": [
                        {
                           "utr": "$sandboxUtr",
@@ -395,7 +388,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
   Scenario("SA interests and dividends endpoint for the sandbox implementation") {
     When("I request the SA interests and dividends income for Sandbox")
     val response = Http(
-      s"$serviceUrl/sandbox/sa/interests-and-dividends?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      s"$serviceUrl/sandbox/sa/interests-and-dividends?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
       .headers(requestHeaders(acceptHeaderP1))
       .asString
 
@@ -406,12 +399,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
         s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/interests-and-dividends?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/interests-and-dividends?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "interestsAndDividends": [
                        {
                          "utr": "$sandboxUtr",
@@ -422,7 +415,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "interestsAndDividends": [
                        {
                           "utr": "$sandboxUtr",
@@ -441,7 +434,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
   Scenario("SA uk-properties endpoint for the sandbox implementation") {
     When("I request the SA uk-properties income for Sandbox")
     val response =
-      Http(s"$serviceUrl/sandbox/sa/uk-properties?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      Http(s"$serviceUrl/sandbox/sa/uk-properties?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP1))
         .asString
 
@@ -452,12 +445,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
         s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/uk-properties?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/uk-properties?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "ukProperties": [
                        {
                          "utr": "$sandboxUtr",
@@ -466,7 +459,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "ukProperties": [
                        {
                           "utr": "$sandboxUtr",
@@ -483,7 +476,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
   Scenario("SA additional-information endpoint for the sandbox implementation") {
     When("I request the SA additional-information income for Sandbox")
     val response = Http(
-      s"$serviceUrl/sandbox/sa/additional-information?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      s"$serviceUrl/sandbox/sa/additional-information?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
       .headers(requestHeaders(acceptHeaderP1))
       .asString
 
@@ -494,12 +487,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
         s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/additional-information?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/additional-information?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "additionalInformation": [
                        {
                          "utr": "$sandboxUtr",
@@ -509,7 +502,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "additionalInformation": [
                        {
                           "utr": "$sandboxUtr",
@@ -526,7 +519,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
 
   Scenario("SA other endpoint for the sandbox implementation") {
     When("I request the SA other income for Sandbox")
-    val response = Http(s"$serviceUrl/sandbox/sa/other?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+    val response = Http(s"$serviceUrl/sandbox/sa/other?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20")
       .headers(requestHeaders(acceptHeaderP1))
       .asString
 
@@ -537,12 +530,12 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
         s"""
              {
                "_links": {
-                 "self": {"href": "/individuals/income/sa/other?matchId=$sandboxMatchId&fromTaxYear=2016-17&toTaxYear=2018-19"}
+                 "self": {"href": "/individuals/income/sa/other?matchId=$sandboxMatchId&fromTaxYear=2017-18&toTaxYear=2019-20"}
                },
                "selfAssessment": {
                  "taxReturns": [
                    {
-                     "taxYear": "2017-18",
+                     "taxYear": "2018-19",
                      "other": [
                        {
                          "utr": "$sandboxUtr",
@@ -551,7 +544,7 @@ class SandboxSaIncomeControllerSpec extends BaseSpec {
                      ]
                    },
                    {
-                     "taxYear": "2016-17",
+                     "taxYear": "2017-18",
                      "other": [
                        {
                           "utr": "$sandboxUtr",

--- a/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/LiveSaIncomeControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsincomeapi/controllers/v2/LiveSaIncomeControllerSpec.scala
@@ -28,8 +28,8 @@ import java.util.UUID
 class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
   val matchId = UUID.randomUUID().toString
-  val fromTaxYear = "2017"
-  val toTaxYear = "2019"
+  val fromTaxYear = "2018"
+  val toTaxYear = "2020"
 
   val nino = "CS700100A"
 
@@ -91,7 +91,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -118,7 +118,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
              |      "title": "Get an individual's SA partnerships data"
              |    },
              |    "self": {
-             |      "href": "/individuals/income/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+             |      "href": "/individuals/income/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
              |    },
              |    "interestsAndDividends": {
              |      "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId{&fromTaxYear,toTaxYear}",
@@ -198,7 +198,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -225,7 +225,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
              |      "title": "Get an individual's SA partnerships data"
              |    },
              |    "self": {
-             |      "href": "/individuals/income/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+             |      "href": "/individuals/income/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
              |    },
              |    "interestsAndDividends": {
              |      "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId{&fromTaxYear,toTaxYear}",
@@ -278,7 +278,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -307,7 +307,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -364,7 +364,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -376,7 +376,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -415,7 +415,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -427,7 +427,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -444,7 +444,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, employmentScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -473,7 +473,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa/employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -530,7 +530,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -542,7 +542,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -581,7 +581,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -593,7 +593,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -610,7 +610,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, selfAssessmentScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -639,7 +639,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa/self-employments?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -698,7 +698,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -710,7 +710,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -749,7 +749,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -761,7 +761,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -778,7 +778,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, summaryScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -807,7 +807,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa/summary?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -857,7 +857,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -869,7 +869,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -907,7 +907,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -919,7 +919,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -936,7 +936,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, trustsScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -949,7 +949,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
     Scenario("The self assessment data source is rate limited") {
 
-      val toTaxYear = "2020"
+      val toTaxYear = "2021"
       Given("A privileged Auth bearer token with the required scopes")
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, trustsScopes)
 
@@ -965,7 +965,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa/trusts?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -1022,7 +1022,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -1034,7 +1034,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1072,7 +1072,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -1084,7 +1084,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1101,7 +1101,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, foreignScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -1130,7 +1130,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa/foreign?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -1187,7 +1187,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -1199,7 +1199,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1237,7 +1237,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
         .headers(headers)
         .asString
 
@@ -1249,7 +1249,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1266,7 +1266,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, partnershipsScopes)
 
       When("I request the self assessments")
-      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -1295,7 +1295,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       )
 
       When("I request the resources")
-      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+      val response = Http(s"$serviceUrl/sa/partnerships?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(headers)
         .asString
 
@@ -1348,7 +1348,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1360,7 +1360,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1401,7 +1401,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
           .headers(headers)
           .asString
 
@@ -1413,7 +1413,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1431,7 +1431,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the self assessments")
       val response =
-        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP2))
           .asString
 
@@ -1461,7 +1461,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+        Http(s"$serviceUrl/sa/interests-and-dividends?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1512,7 +1512,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1524,7 +1524,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1563,7 +1563,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
           .headers(headers)
           .asString
 
@@ -1575,7 +1575,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1593,7 +1593,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the self assessments")
       val response =
-        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP2))
           .asString
 
@@ -1623,7 +1623,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+        Http(s"$serviceUrl/sa/pensions-and-state-benefits?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1676,7 +1676,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1688,7 +1688,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1727,7 +1727,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
           .headers(headers)
           .asString
 
@@ -1739,7 +1739,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1757,7 +1757,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the self assessments")
       val response =
-        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP2))
           .asString
 
@@ -1787,7 +1787,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+        Http(s"$serviceUrl/sa/uk-properties?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1838,7 +1838,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -1850,7 +1850,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1890,7 +1890,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
           .headers(headers)
           .asString
 
@@ -1902,7 +1902,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -1920,7 +1920,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the self assessments")
       val response =
-        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP2))
           .asString
 
@@ -1950,7 +1950,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+        Http(s"$serviceUrl/sa/additional-information?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -2008,7 +2008,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -2020,7 +2020,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -2060,7 +2060,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
           .headers(headers)
           .asString
 
@@ -2072,7 +2072,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -2090,7 +2090,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the self assessments")
       val response =
-        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP2))
           .asString
 
@@ -2120,7 +2120,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+        Http(s"$serviceUrl/sa/other?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -2175,7 +2175,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -2187,7 +2187,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/further-details?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19"
+               |      "href": "/individuals/income/sa/further-details?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20"
                |    }
                |  },
                |  "selfAssessment": {
@@ -2236,7 +2236,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21")
+        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21")
           .headers(headers)
           .asString
 
@@ -2248,7 +2248,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
             s"""{
                |  "_links": {
                |    "self": {
-               |      "href": "/individuals/income/sa/further-details?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2020-21"
+               |      "href": "/individuals/income/sa/further-details?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2020-21"
                |    }
                |  },
                |  "selfAssessment": {
@@ -2266,7 +2266,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the self assessments")
       val response =
-        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(requestHeaders(acceptHeaderP2))
           .asString
 
@@ -2296,7 +2296,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("I request the resources")
       val response =
-        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2019-20")
+        Http(s"$serviceUrl/sa/further-details?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
           .headers(headers)
           .asString
 
@@ -2316,7 +2316,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthToken(authToken, scopes)
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2333,7 +2333,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willNotAuthorizePrivilegedAuthTokenNoScopes(authToken)
 
       When("the API is invoked")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2371,7 +2371,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       When(
         s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
 
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2395,7 +2395,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When(
         s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2420,7 +2420,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When(
         s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2441,7 +2441,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
 
       When("the API is invoked with a missing match id")
 
-      val response = Http(s"$serviceUrl/$endpoint?fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2460,7 +2460,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the API is invoked with a malformed match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=malformed-id&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=malformed-id&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2479,7 +2479,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the paye endpoint is invoked with an invalid match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2500,7 +2500,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the endpoint is invoked with an invalid match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2519,7 +2519,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the endpoint is invoked with an invalid match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2018-19&toTaxYear=2016-17")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2019-20&toTaxYear=2017-18")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2538,7 +2538,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the endpoint is invoked with an invalid match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2012-13&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2012-13&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2557,7 +2557,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the endpoint is invoked with an invalid match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=201632A-17&toTaxYear=2018-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=201632A-17&toTaxYear=2019-20")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 
@@ -2576,7 +2576,7 @@ class LiveSaIncomeControllerSpec extends BaseSpec with IncomeSaHelpers {
       AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScopes)
 
       When("the endpoint is invoked with an invalid match id")
-      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2016-17&toTaxYear=2018GFR-19")
+      val response = Http(s"$serviceUrl/$endpoint?matchId=$matchId&fromTaxYear=2017-18&toTaxYear=2018GFR-19")
         .headers(requestHeaders(acceptHeaderP2))
         .asString
 

--- a/test/unit/uk/gov/hmrc/individualsincomeapi/services/v1/SaIncomeServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsincomeapi/services/v1/SaIncomeServiceSpec.scala
@@ -95,10 +95,10 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
         registrations = Seq(SaRegistration(SaUtr("2432552635"), Some(LocalDate.parse("2015-01-06")))),
         taxReturns = Seq(
           v1.SaTaxReturn(
-            TaxYear("2017-18"),
+            TaxYear("2018-19"),
             Seq(SaSubmission(SaUtr("2432552635"), Some(LocalDate.parse("2018-10-06"))))),
           v1.SaTaxReturn(
-            TaxYear("2016-17"),
+            TaxYear("2017-18"),
             Seq(SaSubmission(SaUtr("2432552635"), Some(LocalDate.parse("2017-06-06")))))
         )
       )
@@ -106,16 +106,16 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
 
     "filter out returns not in the requested period" in new Setup {
       val result = await(
-        sandboxSaIncomeService.fetchSaFootprint(sandboxMatchId, taxYearInterval.copy(toTaxYear = TaxYear("2016-17"))))
+        sandboxSaIncomeService.fetchSaFootprint(sandboxMatchId, taxYearInterval.copy(toTaxYear = TaxYear("2017-18"))))
 
       result.taxReturns shouldBe Seq(
-        v1.SaTaxReturn(TaxYear("2016-17"), Seq(SaSubmission(SaUtr("2432552635"), Some(LocalDate.parse("2017-06-06"))))))
+        v1.SaTaxReturn(TaxYear("2017-18"), Seq(SaSubmission(SaUtr("2432552635"), Some(LocalDate.parse("2017-06-06"))))))
     }
 
     "return an empty footprint when no annual return exists for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchSaFootprint(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchSaFootprint(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
 
       result shouldBe SaFootprint(Seq.empty, Seq.empty)
     }
@@ -157,28 +157,28 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the employments income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2018-19"))))
+          .fetchEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2019-20"))))
 
       result shouldBe Seq(
-        v1.SaAnnualEmployments(TaxYear("2017-18"), Seq(SaEmploymentsIncome(sandboxUtr, 0))),
-        v1.SaAnnualEmployments(TaxYear("2016-17"), Seq(SaEmploymentsIncome(sandboxUtr, 5000)))
+        v1.SaAnnualEmployments(TaxYear("2018-19"), Seq(SaEmploymentsIncome(sandboxUtr, 0))),
+        v1.SaAnnualEmployments(TaxYear("2017-18"), Seq(SaEmploymentsIncome(sandboxUtr, 5000)))
       )
     }
 
     "filter out employments income not in the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchEmploymentsIncome(sandboxMatchId, taxYearInterval.copy(fromTaxYear = TaxYear("2017-18"))))
+          .fetchEmploymentsIncome(sandboxMatchId, taxYearInterval.copy(fromTaxYear = TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualEmployments(TaxYear("2017-18"), Seq(SaEmploymentsIncome(sandboxUtr, 0)))
+        v1.SaAnnualEmployments(TaxYear("2018-19"), Seq(SaEmploymentsIncome(sandboxUtr, 0)))
       )
     }
 
     "return an empty list when no employments income exists for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
 
       result shouldBe Seq()
     }
@@ -220,18 +220,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the self employments income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchSelfEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchSelfEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualSelfEmployments(TaxYear("2017-18"), Seq(SaSelfEmploymentsIncome(sandboxUtr, 0.0))),
-        v1.SaAnnualSelfEmployments(TaxYear("2016-17"), Seq(SaSelfEmploymentsIncome(sandboxUtr, 10500)))
+        v1.SaAnnualSelfEmployments(TaxYear("2018-19"), Seq(SaSelfEmploymentsIncome(sandboxUtr, 0.0))),
+        v1.SaAnnualSelfEmployments(TaxYear("2017-18"), Seq(SaSelfEmploymentsIncome(sandboxUtr, 10500)))
       )
     }
 
     "return an empty list when no self employments exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchSelfEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchSelfEmploymentsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -239,7 +239,7 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
       intercept[MatchNotFoundException] {
         await(
           sandboxSaIncomeService
-            .fetchSelfEmploymentsIncome(UUID.randomUUID(), TaxYearInterval(TaxYear("2016-17"), TaxYear("2018-19"))))
+            .fetchSelfEmploymentsIncome(UUID.randomUUID(), TaxYearInterval(TaxYear("2017-18"), TaxYear("2019-20"))))
       }
     }
   }
@@ -272,18 +272,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa tax return summaries by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchReturnsSummary(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchReturnsSummary(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaTaxReturnSummaries(TaxYear("2017-18"), Seq(SaTaxReturnSummary(sandboxUtr, 0.0))),
-        v1.SaTaxReturnSummaries(TaxYear("2016-17"), Seq(SaTaxReturnSummary(sandboxUtr, 30000)))
+        v1.SaTaxReturnSummaries(TaxYear("2018-19"), Seq(SaTaxReturnSummary(sandboxUtr, 0.0))),
+        v1.SaTaxReturnSummaries(TaxYear("2017-18"), Seq(SaTaxReturnSummary(sandboxUtr, 30000)))
       )
     }
 
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchReturnsSummary(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchReturnsSummary(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -324,18 +324,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa trusts by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchTrustsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchTrustsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualTrustIncomes(TaxYear("2017-18"), Seq(SaAnnualTrustIncome(sandboxUtr, 0))),
-        v1.SaAnnualTrustIncomes(TaxYear("2016-17"), Seq(SaAnnualTrustIncome(sandboxUtr, 2143.32)))
+        v1.SaAnnualTrustIncomes(TaxYear("2018-19"), Seq(SaAnnualTrustIncome(sandboxUtr, 0))),
+        v1.SaAnnualTrustIncomes(TaxYear("2017-18"), Seq(SaAnnualTrustIncome(sandboxUtr, 2143.32)))
       )
     }
 
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchReturnsSummary(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchReturnsSummary(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -376,18 +376,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa foreign income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchForeignIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchForeignIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualForeignIncomes(TaxYear("2017-18"), Seq(SaAnnualForeignIncome(sandboxUtr, 0))),
-        v1.SaAnnualForeignIncomes(TaxYear("2016-17"), Seq(SaAnnualForeignIncome(sandboxUtr, 1054.65)))
+        v1.SaAnnualForeignIncomes(TaxYear("2018-19"), Seq(SaAnnualForeignIncome(sandboxUtr, 0))),
+        v1.SaAnnualForeignIncomes(TaxYear("2017-18"), Seq(SaAnnualForeignIncome(sandboxUtr, 1054.65)))
       )
     }
 
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchForeignIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchForeignIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -428,18 +428,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa partnership income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchPartnershipsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchPartnershipsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualPartnershipIncomes(TaxYear("2017-18"), Seq(SaAnnualPartnershipIncome(sandboxUtr, 0))),
-        v1.SaAnnualPartnershipIncomes(TaxYear("2016-17"), Seq(SaAnnualPartnershipIncome(sandboxUtr, 324.54)))
+        v1.SaAnnualPartnershipIncomes(TaxYear("2018-19"), Seq(SaAnnualPartnershipIncome(sandboxUtr, 0))),
+        v1.SaAnnualPartnershipIncomes(TaxYear("2017-18"), Seq(SaAnnualPartnershipIncome(sandboxUtr, 324.54)))
       )
     }
 
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchPartnershipsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchPartnershipsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -484,14 +484,14 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa interests and dividends income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchInterestsAndDividendsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchInterestsAndDividendsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
         v1.SaAnnualInterestAndDividendIncomes(
-          TaxYear("2017-18"),
+          TaxYear("2018-19"),
           Seq(SaAnnualInterestAndDividendIncome(sandboxUtr, 0, 0, 0))),
         v1.SaAnnualInterestAndDividendIncomes(
-          TaxYear("2016-17"),
+          TaxYear("2017-18"),
           Seq(SaAnnualInterestAndDividendIncome(sandboxUtr, 12.46, 25.86, 657.89)))
       )
     }
@@ -499,14 +499,14 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchInterestsAndDividendsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchInterestsAndDividendsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
     "fail with MatchNotFoundException when the matchId is not the sandbox matchId" in new Setup {
       intercept[MatchNotFoundException] {
         await(sandboxSaIncomeService
-          .fetchInterestsAndDividendsIncome(UUID.randomUUID(), TaxYearInterval(TaxYear("2016-17"), TaxYear("2018-19"))))
+          .fetchInterestsAndDividendsIncome(UUID.randomUUID(), TaxYearInterval(TaxYear("2017-18"), TaxYear("2019-20"))))
       }
     }
   }
@@ -539,18 +539,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa UK properties income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchUkPropertiesIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchUkPropertiesIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualUkPropertiesIncomes(TaxYear("2017-18"), Seq(SaAnnualUkPropertiesIncome(sandboxUtr, 0))),
-        v1.SaAnnualUkPropertiesIncomes(TaxYear("2016-17"), Seq(SaAnnualUkPropertiesIncome(sandboxUtr, 1276.67)))
+        v1.SaAnnualUkPropertiesIncomes(TaxYear("2018-19"), Seq(SaAnnualUkPropertiesIncome(sandboxUtr, 0))),
+        v1.SaAnnualUkPropertiesIncomes(TaxYear("2017-18"), Seq(SaAnnualUkPropertiesIncome(sandboxUtr, 1276.67)))
       )
     }
 
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchUkPropertiesIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchUkPropertiesIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -593,14 +593,14 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa pensions and state benefits income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchPensionsAndStateBenefitsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchPensionsAndStateBenefitsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
         v1.SaAnnualPensionAndStateBenefitIncomes(
-          TaxYear("2017-18"),
+          TaxYear("2018-19"),
           Seq(SaAnnualPensionAndStateBenefitIncome(sandboxUtr, 0))),
         v1.SaAnnualPensionAndStateBenefitIncomes(
-          TaxYear("2016-17"),
+          TaxYear("2017-18"),
           Seq(SaAnnualPensionAndStateBenefitIncome(sandboxUtr, 52.79)))
       )
     }
@@ -608,7 +608,7 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchPensionsAndStateBenefitsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchPensionsAndStateBenefitsIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -650,12 +650,12 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa additional information by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchAdditionalInformation(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchAdditionalInformation(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualAdditionalInformations(TaxYear("2017-18"), Seq(SaAnnualAdditionalInformation(sandboxUtr, 0, 0))),
+        v1.SaAnnualAdditionalInformations(TaxYear("2018-19"), Seq(SaAnnualAdditionalInformation(sandboxUtr, 0, 0))),
         v1.SaAnnualAdditionalInformations(
-          TaxYear("2016-17"),
+          TaxYear("2017-18"),
           Seq(SaAnnualAdditionalInformation(sandboxUtr, 44.54, 52.34)))
       )
     }
@@ -663,7 +663,7 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchAdditionalInformation(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchAdditionalInformation(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 
@@ -704,18 +704,18 @@ class SaIncomeServiceSpec extends TestSupport with MockitoSugar with ScalaFuture
     "return the sa other income by tax year DESCENDING when the matchId is valid" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchOtherIncome(sandboxMatchId, TaxYearInterval(TaxYear("2016-17"), TaxYear("2017-18"))))
+          .fetchOtherIncome(sandboxMatchId, TaxYearInterval(TaxYear("2017-18"), TaxYear("2018-19"))))
 
       result shouldBe Seq(
-        v1.SaAnnualOtherIncomes(TaxYear("2017-18"), Seq(SaAnnualOtherIncome(sandboxUtr, 0))),
-        v1.SaAnnualOtherIncomes(TaxYear("2016-17"), Seq(SaAnnualOtherIncome(sandboxUtr, 26.70)))
+        v1.SaAnnualOtherIncomes(TaxYear("2018-19"), Seq(SaAnnualOtherIncome(sandboxUtr, 0))),
+        v1.SaAnnualOtherIncomes(TaxYear("2017-18"), Seq(SaAnnualOtherIncome(sandboxUtr, 26.70)))
       )
     }
 
     "return an empty list when no sa tax returns exist for the requested period" in new Setup {
       val result = await(
         sandboxSaIncomeService
-          .fetchOtherIncome(sandboxMatchId, TaxYearInterval(TaxYear("2018-19"), TaxYear("2018-19"))))
+          .fetchOtherIncome(sandboxMatchId, TaxYearInterval(TaxYear("2019-20"), TaxYear("2019-20"))))
       result shouldBe Seq.empty
     }
 


### PR DESCRIPTION
[Ticket](https://jira.tools.tax.service.gov.uk/browse/DLS-6071)

This reverts commit dcfef82456078a71d353045f2aeca5635aef5b52, reversing changes made to 6538425bdfaaf4c40ce71b09326b145221166cb3.

This will make the API once again expect IF to contain "NO_DATA_FOUND" body when no data is found for the queried entry rather than an empty body. A fix is implemented on IF's side.