### PR TITLE
DLS-7473 Useful Logging

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/connector/IfConnector.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/connector/IfConnector.scala
@@ -162,7 +162,7 @@ class IfConnector @Inject()(servicesConfig: ServicesConfig, http: HttpClient, va
       Future.failed(new InternalServerException("Something went wrong."))
     }
     case e: Exception => {
-      logger.warn(s"Integration Framework Exception encountered")
+      logger.error(s"Integration Framework Exception encountered", e)
       auditHelper.auditIfApiFailure(correlationId, matchId, request, requestUrl, e.getMessage)
       Future.failed(new InternalServerException("Something went wrong."))
     }

--- a/app/uk/gov/hmrc/individualsincomeapi/controllers/v1/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/controllers/v1/CommonController.scala
@@ -89,13 +89,8 @@ abstract class CommonController @Inject()(cc: ControllerComponents) extends Back
       auditHelper.auditApiFailure(correlationId, matchId, request, url, e.getMessage)
       ErrorInvalidRequest(e.getMessage).toHttpResponse
     }
-    case e: InternalServerException => {
-      logger.warn("Controllers InternalServerException encountered")
-      auditHelper.auditApiFailure(correlationId, matchId, request, url, e.getMessage)
-      ErrorInternalServer("Something went wrong.").toHttpResponse
-    }
     case e: Exception => {
-      logger.warn("Controllers Exception encountered")
+      logger.error("Controllers Exception encountered", e)
       auditHelper.auditApiFailure(correlationId, matchId, request, url, e.getMessage)
       ErrorInternalServer("Something went wrong.").toHttpResponse
     }

--- a/app/uk/gov/hmrc/individualsincomeapi/controllers/v2/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/controllers/v2/CommonController.scala
@@ -84,12 +84,8 @@ abstract class CommonController @Inject()(cc: ControllerComponents) extends Back
       logger.warn("Controllers IllegalArgumentException encountered")
       auditHelper.auditApiFailure(correlationId, matchId, request, url, e.getMessage)
       ErrorInvalidRequest(e.getMessage).toHttpResponse
-    case e: InternalServerException =>
-      logger.warn("Controllers InternalServerException encountered")
-      auditHelper.auditApiFailure(correlationId, matchId, request, url, e.getMessage)
-      ErrorInternalServer("Something went wrong.").toHttpResponse
     case e: Exception =>
-      logger.warn("Controllers Exception encountered")
+      logger.error("Controllers Exception encountered", e)
       auditHelper.auditApiFailure(correlationId, matchId, request, url, e.getMessage)
       ErrorInternalServer("Something went wrong.").toHttpResponse
   }


### PR DESCRIPTION
Branch with an extra endpoint for local testing (just hit `/admin/nuke`):

https://github.com/hmrc/individuals-income-api/tree/lajw/DLS-7473/Useful-Logging-Test

Makes it so that the unexpected errors that would normally result in error 500s now should show up in the Kibana exception dashboard with the stack trace, name and cause of the exception.