### PR TITLE
DLS-11839 : Reverted back code coverage settings

### DIFF
--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -18,7 +18,7 @@ object CodeCoverageSettings {
 
   val settings: Seq[Setting[?]] = Seq(
     ScoverageKeys.coverageExcludedPackages := excludedPackages.mkString(";"),
-    ScoverageKeys.coverageMinimumStmtTotal := 75,
+    ScoverageKeys.coverageMinimumStmtTotal := 80,
     ScoverageKeys.coverageFailOnMinimum := true,
     ScoverageKeys.coverageHighlighting := true
   )


### PR DESCRIPTION
Statement coverage is already 94.23%, and Branch coverage is 86.07%, hence reverted minimum stmtTotal to 80% 