### PR TITLE
DLS-12860 | Remove validation errors logging

### DIFF
--- a/app/uk/gov/hmrc/individualsincomeapi/connector/IfConnector.scala
+++ b/app/uk/gov/hmrc/individualsincomeapi/connector/IfConnector.scala
@@ -136,7 +136,7 @@ class IfConnector @Inject() (servicesConfig: ServicesConfig, http: HttpClientV2,
         requestUrl,
         s"Error parsing IF response: ${validationError.errors}"
       )
-      Future.failed(new InternalServerException(s"Something went wrong: ${validationError.errors}"))
+      Future.failed(new InternalServerException(s"Something went wrong"))
 
     case UpstreamErrorResponse(msg, 404, _, _) =>
       auditHelper.auditIfApiFailure(correlationId, matchId, request, requestUrl, msg)


### PR DESCRIPTION
Logging of validation errors was temporary to debug issues on ET as we weren't able to retrieve splunk logs for SCTS correlation ids. Removing it now, otherwise it would log payloads there by exposing PII information to logs in production.